### PR TITLE
Custom mode with cpu and gpu boost option

### DIFF
--- a/driver/src/core.h
+++ b/driver/src/core.h
@@ -36,7 +36,9 @@ typedef struct razer_laptop {
     struct mutex lock; // Lock mutex
     struct usb_device *usb_dev;	// USB Device for communication
     __u16 fan_rpm; // Fan RPM Set by driver (0 if it is auto!)
-    __u8 power_mode; // Power mode (0 = normal, 1 = gaming, 2 = creator)
+    __u8 power_mode; // Power mode (0 = normal, 1 = gaming, 2 = creator, 4 = custom)
+    __u8 cpu_boost; // only for custom mode
+    __u8 gpu_boost; // only for custom mode
     keyboard_info kbd; // Keyboard data
 } razer_laptop;
 

--- a/driver/src/fancontrol.c
+++ b/driver/src/fancontrol.c
@@ -43,6 +43,7 @@ int creator_mode_allowed(__u32 product_id)
 	switch (product_id) {
 	case BLADE_2019_ADV:
 	case BLADE_2019_MERC:
+    case BLADE_2020_ADV:
 		return 1;
 	default:
 		return 0;

--- a/driver/src/fancontrol.c
+++ b/driver/src/fancontrol.c
@@ -50,88 +50,102 @@ int creator_mode_allowed(__u32 product_id)
 	}
 }
 
+int boost_mode_allowed(__u32 product_id)
+{
+    switch (product_id) {
+    case BLADE_2020_ADV:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 void set_fan_rpm(unsigned long x, struct razer_laptop *laptop) {
     mutex_lock(&laptop->lock);
-    u8 request_fan_speed;
-    char buffer[90] = {0x00};
-    if (x != 0) {
-        request_fan_speed = clamp_fan_rpm(x, laptop->product_id);
-        laptop->fan_rpm = request_fan_speed * 100;
-        // All packets
-        buffer[0] = 0x00;
-        buffer[1] = 0x1f;
-        buffer[2] = 0x00;
-        buffer[3] = 0x00;
-        buffer[4] = 0x00;
+    if(laptop->power_mode < 4) // custom mode do not support fan profile
+    {
+        u8 request_fan_speed;
+        char buffer[90] = {0x00};
+        if (x != 0) {
+            request_fan_speed = clamp_fan_rpm(x, laptop->product_id);
+            laptop->fan_rpm = request_fan_speed * 100;
+            // All packets
+            buffer[0] = 0x00;
+            buffer[1] = 0x1f;
+            buffer[2] = 0x00;
+            buffer[3] = 0x00;
+            buffer[4] = 0x00;
 
-        // Unknown
-        buffer[5] = 0x04;
-        buffer[6] = 0x0d;
-        buffer[7] = 0x82;
-        buffer[8] = 0x00;
-        buffer[9] = 0x01;
-        buffer[10] = 0x00;
-        buffer[11] = 0x00;
-        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+            // Unknown
+            buffer[5] = 0x04;
+            buffer[6] = 0x0d;
+            buffer[7] = 0x82;
+            buffer[8] = 0x00;
+            buffer[9] = 0x01;
+            buffer[10] = 0x00;
+            buffer[11] = 0x00;
+            send_payload(laptop->usb_dev, buffer, 3400, 3800);
 
-        // Unknown
+            // Unknown
+            buffer[5] = 0x04;
+            buffer[6] = 0x0d;
+            buffer[7] = 0x02;
+            buffer[8] = 0x00;
+            buffer[9] = 0x01;
+            buffer[10] = laptop->power_mode;
+            buffer[11] = laptop->fan_rpm != 0 ? 0x01 : 0x00;
+            send_payload(laptop->usb_dev, buffer, 204000, 205000);
+
+            // Set fan RPM
+            buffer[5] = 0x03;
+            buffer[6] = 0x0d;
+            buffer[7] = 0x01;
+            buffer[8] = 0x00;
+            buffer[9] = 0x01;
+            buffer[10] = request_fan_speed;
+            buffer[11] = 0x00;
+            send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+            // Unknown
+            buffer[5] = 0x04;
+            buffer[6] = 0x0d;
+            buffer[7] = 0x82;
+            buffer[8] = 0x00;
+            buffer[9] = 0x02;
+            buffer[10] = 0x00;
+            buffer[11] = 0x00;
+            send_payload(laptop->usb_dev, buffer, 3400, 3800);
+        } else {
+            laptop->fan_rpm = 0;
+        }
+        // Fan mode
         buffer[5] = 0x04;
         buffer[6] = 0x0d;
         buffer[7] = 0x02;
         buffer[8] = 0x00;
-        buffer[9] = 0x01;
+        buffer[9] = 0x02;
         buffer[10] = laptop->power_mode;
         buffer[11] = laptop->fan_rpm != 0 ? 0x01 : 0x00;
         send_payload(laptop->usb_dev, buffer, 204000, 205000);
 
-        // Set fan RPM
-        buffer[5] = 0x03;
-        buffer[6] = 0x0d;
-        buffer[7] = 0x01;
-        buffer[8] = 0x00;
-        buffer[9] = 0x01;
-        buffer[10] = request_fan_speed;
-        buffer[11] = 0x00;
-        send_payload(laptop->usb_dev, buffer, 3400, 3800);
-
-        // Unknown
-        buffer[5] = 0x04;
-        buffer[6] = 0x0d;
-        buffer[7] = 0x82;
-        buffer[8] = 0x00;
-        buffer[9] = 0x02;
-        buffer[10] = 0x00;
-        buffer[11] = 0x00;
-        send_payload(laptop->usb_dev, buffer, 3400, 3800);
-    } else {
-        laptop->fan_rpm = 0;
-    }
-    // Fan mode
-    buffer[5] = 0x04;
-    buffer[6] = 0x0d;
-    buffer[7] = 0x02;
-    buffer[8] = 0x00;
-    buffer[9] = 0x02;
-    buffer[10] = laptop->power_mode;
-    buffer[11] = laptop->fan_rpm != 0 ? 0x01 : 0x00;
-    send_payload(laptop->usb_dev, buffer, 204000, 205000);
-
-    if (x != 0) {
-        // Set fan RPM
-        buffer[5] = 0x03;
-        buffer[6] = 0x0d;
-        buffer[7] = 0x01;
-        buffer[8] = 0x00;
-        buffer[9] = 0x02;
-        buffer[10] = request_fan_speed;
-        buffer[11] = 0x00;
-        send_payload(laptop->usb_dev, buffer, 0, 0);
+        if (x != 0) {
+            // Set fan RPM
+            buffer[5] = 0x03;
+            buffer[6] = 0x0d;
+            buffer[7] = 0x01;
+            buffer[8] = 0x00;
+            buffer[9] = 0x02;
+            buffer[10] = request_fan_speed;
+            buffer[11] = 0x00;
+            send_payload(laptop->usb_dev, buffer, 0, 0);
+        }
     }
     mutex_unlock(&laptop->lock);
 }
 
 int set_power_mode(unsigned long x, struct razer_laptop *laptop) {
     mutex_lock(&laptop->lock);
+    int res = 0;
     if (x >= 0 && x <= 2) {
         char buffer[90];
         // Device doesn't support creator mode
@@ -155,7 +169,121 @@ int set_power_mode(unsigned long x, struct razer_laptop *laptop) {
         buffer[9] = 0x01;
         buffer[10] = laptop->power_mode;
         buffer[11] = laptop->fan_rpm != 0 ? 0x01 : 0x00; // Custom RPM?
-        send_payload(laptop->usb_dev, buffer, 0, 0);
+        res = send_payload(laptop->usb_dev, buffer, 0, 0);
+    }
+    else if(x == 4)
+    {
+        laptop->power_mode = x;
     }
     mutex_unlock(&laptop->lock);
+
+    return res;
+}
+
+int set_custom_power_mode(unsigned long cpu_boost, unsigned long gpu_boost, struct razer_laptop *laptop)
+{
+    mutex_lock(&laptop->lock);
+    if(laptop->power_mode == 4)
+    {
+        char buffer[90];
+        if(cpu_boost == 3 && !boost_mode_allowed(laptop->product_id))
+        {
+            cpu_boost = 2;
+        }
+
+        laptop->cpu_boost = cpu_boost;
+        laptop->gpu_boost = gpu_boost;
+        memset(buffer, 0x00, sizeof(buffer));
+
+        // All packets
+        buffer[0] = 0x00;
+        buffer[1] = 0x1f;
+        buffer[2] = 0x00;
+        buffer[3] = 0x00;
+        buffer[4] = 0x00;
+
+        // Begin transaction
+        buffer[5] = 0x04;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x82;
+        buffer[8] = 0x00;
+        buffer[9] = 0x01;
+        buffer[10] = 0x00;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // Set power mode custom
+        buffer[5] = 0x04;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x02;
+        buffer[8] = 0x00;
+        buffer[9] = 0x01;
+        buffer[10] = laptop->power_mode;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // Clear cpu boost
+        buffer[5] = 0x03;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x87;
+        buffer[8] = 0x00;
+        buffer[9] = 0x01;
+        buffer[10] = 0x00;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // Set cpu boost
+        buffer[5] = 0x03;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x07;
+        buffer[8] = 0x00;
+        buffer[9] = 0x01;
+        buffer[10] = laptop->cpu_boost;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // Clear gpu boost
+        buffer[5] = 0x03;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x87;
+        buffer[8] = 0x00;
+        buffer[9] = 0x02;
+        buffer[10] = 0x00;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // Set gpu boost
+        buffer[5] = 0x03;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x07;
+        buffer[8] = 0x00;
+        buffer[9] = 0x02;
+        buffer[10] = laptop->gpu_boost;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // End transaction
+        buffer[5] = 0x04;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x82;
+        buffer[8] = 0x00;
+        buffer[9] = 0x02;
+        buffer[10] = 0x00;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+
+        // End set power mode
+        buffer[5] = 0x04;
+        buffer[6] = 0x0d;
+        buffer[7] = 0x82;
+        buffer[8] = 0x00;
+        buffer[9] = 0x02;
+        buffer[10] = laptop->power_mode;
+        buffer[11] = 0x00;
+        send_payload(laptop->usb_dev, buffer, 3400, 3800);
+    }
+    mutex_unlock(&laptop->lock);
+
+    // always 0 since send_payload return only 0
+    return 0;
 }

--- a/driver/src/fancontrol.h
+++ b/driver/src/fancontrol.h
@@ -32,9 +32,11 @@ u8 clamp_fan_rpm(unsigned int rpm, __u32 product_id);
  * which raises just GPU power
  */
 int creator_mode_allowed(__u32 product_id);
+int boost_mode_allowed(__u32 product_id);
 
 void set_fan_rpm(unsigned long x, struct razer_laptop *laptop);
 
 int set_power_mode(unsigned long x, struct razer_laptop *laptop);
+int set_custom_power_mode(unsigned long cpu_boost, unsigned long gpu_boost, struct razer_laptop *laptop);
 
 #endif

--- a/razer_control_gui/src/cli.rs
+++ b/razer_control_gui/src/cli.rs
@@ -160,6 +160,31 @@ fn read_power_mode() {
                 _ => "Unknown"
             };
             println!("Current power setting: {}", power_desc);
+            if pwr == 4 {
+                if let Some(resp) = send_data(comms::DaemonCommand::GetCPUBoost()) {
+                    if let comms::DaemonResponse::GetCPUBoost {cpu } = resp {
+                        let cpu_boost_desc : &str = match cpu {
+                            0 => "Low",
+                            1 => "Medium",
+                            2 => "High",
+                            3 => "Boost",
+                            _ => "Unknown"
+                        };
+                        println!("Current CPU setting: {}", cpu_boost_desc);
+                    };
+                }
+                if let Some(resp) = send_data(comms::DaemonCommand::GetGPUBoost()) {
+                    if let comms::DaemonResponse::GetGPUBoost {gpu } = resp {
+                        let gpu_boost_desc : &str = match gpu {
+                            0 => "Low",
+                            1 => "Medium",
+                            2 => "High",
+                            _ => "Unknown"
+                        };
+                        println!("Current GPU setting: {}", gpu_boost_desc);
+                    };
+                }
+            }
         } else {
             eprintln!("Daemon responded with invalid data!");
         }

--- a/razer_control_gui/src/cli.rs
+++ b/razer_control_gui/src/cli.rs
@@ -156,6 +156,7 @@ fn read_power_mode() {
                 0 => "Balanced",
                 1 => "Gaming",
                 2 => "Creator",
+                4 => "Custom",
                 _ => "Unknown"
             };
             println!("Current power setting: {}", power_desc);

--- a/razer_control_gui/src/comms.rs
+++ b/razer_control_gui/src/comms.rs
@@ -12,6 +12,8 @@ pub enum DaemonCommand {
     GetFanSpeed(),                 // Get (Fan speed)
     SetPowerMode { pwr: u8, cpu: u8, gpu: u8},      // Power mode
     GetPwrLevel(),                 // Get (Power mode)
+    GetCPUBoost(),                 // Get (CPU boost)
+    GetGPUBoost(),                 // Get (GPU boost)
     GetKeyboardRGB { layer: i32 }, // Layer ID
     GetCfg(),                      // Request curr settings for fan + power
     SetEffect { name: String, params: Vec<u8> } // Set keyboard colour
@@ -25,6 +27,8 @@ pub enum DaemonResponse {
     GetFanSpeed { rpm: i32 },                        // Get (Fan speed)
     SetPowerMode { result: bool },                   // Response
     GetPwrLevel { pwr: u8 },                         // Get (Power mode)
+    GetCPUBoost { cpu: u8 },                         // Get (CPU boost)
+    GetGPUBoost { gpu: u8 },                         // Get (GPU boost)
     GetKeyboardRGB { layer: i32, rgbdata: Vec<u8> }, // Response (RGB) of 90 keys
     GetCfg { fan_rpm: i32, pwr: u8 },                // Fan speed, power mode
     SetEffect { result: bool }                       // Set keyboard colour

--- a/razer_control_gui/src/comms.rs
+++ b/razer_control_gui/src/comms.rs
@@ -10,7 +10,7 @@ pub const SOCKET_PATH: &'static str = "/tmp/razercontrol-socket";
 pub enum DaemonCommand {
     SetFanSpeed { rpm: i32 },      // Fan speed
     GetFanSpeed(),                 // Get (Fan speed)
-    SetPowerMode { pwr: u8 },      // Power mode
+    SetPowerMode { pwr: u8, cpu: u8, gpu: u8},      // Power mode
     GetPwrLevel(),                 // Get (Power mode)
     GetKeyboardRGB { layer: i32 }, // Layer ID
     GetCfg(),                      // Request curr settings for fan + power

--- a/razer_control_gui/src/config.rs
+++ b/razer_control_gui/src/config.rs
@@ -10,6 +10,8 @@ const EFFECTS_FILE: &str = "/usr/share/razercontrol/effects.json";
 #[derive(Serialize, Deserialize)]
 pub struct Configuration {
     pub power_mode: u8,
+    pub cpu_boost: u8,
+    pub gpu_boost: u8,
     pub fan_rpm: i32,
     pub brightness: u8,
 }
@@ -18,6 +20,8 @@ impl Configuration {
     pub fn new() -> Configuration {
         return Configuration {
             power_mode: 0,
+            cpu_boost: 0,
+            gpu_boost: 0,
             fan_rpm: 0,
             brightness: 128,
         };

--- a/razer_control_gui/src/daemon.rs
+++ b/razer_control_gui/src/daemon.rs
@@ -165,6 +165,8 @@ pub fn process_client_request(cmd: comms::DaemonCommand) -> Option<comms::Daemon
         }
         comms::DaemonCommand::GetFanSpeed() => Some(comms::DaemonResponse::GetFanSpeed { rpm: driver_sysfs::read_fan_rpm() }),
         comms::DaemonCommand::GetPwrLevel() => Some(comms::DaemonResponse::GetPwrLevel { pwr: driver_sysfs::read_power() }),
+        comms::DaemonCommand::GetCPUBoost() => Some(comms::DaemonResponse::GetCPUBoost { cpu: driver_sysfs::read_cpu_boost() }),
+        comms::DaemonCommand::GetGPUBoost() => Some(comms::DaemonResponse::GetGPUBoost { gpu: driver_sysfs::read_gpu_boost() }),
         comms::DaemonCommand::SetEffect{ name, params } => {
             let mut res = false;
             if let Ok(mut k) = EFFECT_MANAGER.lock() {

--- a/razer_control_gui/src/driver_sysfs.rs
+++ b/razer_control_gui/src/driver_sysfs.rs
@@ -74,8 +74,8 @@ pub fn read_brightness() -> u8 {
 }
 
 // Power mode is read + write
-pub fn write_power(mode: u8) -> bool {
-    return write_to_sysfs("power_mode", String::from(format!("{}", mode)));
+pub fn write_power(mode: u8, cpu_boost: u8, gpu_boost: u8) -> bool {
+    return write_to_sysfs("power_mode", String::from(format!("{} {} {}", mode, cpu_boost, gpu_boost)));
 }
 
 pub fn read_power() -> u8 {

--- a/razer_control_gui/src/driver_sysfs.rs
+++ b/razer_control_gui/src/driver_sysfs.rs
@@ -74,8 +74,18 @@ pub fn read_brightness() -> u8 {
 }
 
 // Power mode is read + write
-pub fn write_power(mode: u8, cpu_boost: u8, gpu_boost: u8) -> bool {
-    return write_to_sysfs("power_mode", String::from(format!("{} {} {}", mode, cpu_boost, gpu_boost)));
+pub fn write_power(mode: u8) -> bool {
+    return write_to_sysfs("power_mode", String::from(format!("{}", mode)));
+}
+
+// cpu_boost read + write
+pub fn write_cpu_boost(cpu_boost: u8) -> bool {
+    return write_to_sysfs("cpu_boost", String::from(format!("{}", cpu_boost)));
+}
+
+//gpu_boost is read + write
+pub fn write_gpu_boost(gpu_boost: u8) -> bool {
+    return write_to_sysfs("gpu_boost", String::from(format!("{}", gpu_boost)));
 }
 
 pub fn read_power() -> u8 {
@@ -85,6 +95,19 @@ pub fn read_power() -> u8 {
     };
 }
 
+pub fn read_cpu_boost() -> u8 {
+    return match read_from_sysfs("cpu_boost") {
+        Some(x) => x.parse::<u8>().unwrap(),
+        None => 0,
+    };
+}
+
+pub fn read_gpu_boost() -> u8 {
+    return match read_from_sysfs("gpu_boost") {
+        Some(x) => x.parse::<u8>().unwrap(),
+        None => 0,
+    };
+}
 /// Writes fan RPM to sysfs, and returns result of the write
 /// # Arguments
 /// * `rpm` - Fan RPM to write to sysfs. 0 imples back to automatic fan


### PR DESCRIPTION
This will close #46, I am currently using it. 

CPU:
low -> 25W
medium -> 35W
high- > 45W (same as gaming and creator)
boost -> 55W (work only on 2020 Blade Advanced and Studio)

GPU:
don't know levels but it is faster

