### PR TITLE
Add Fedora Workstation and secure-boot sections in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,45 @@ Use the 2 PKGBUILDS located here:
 * [DKMS Driver](https://aur.archlinux.org/packages/razer-laptop-control-dkms-git/)
 * [CLI and Daemon](https://aur.archlinux.org/packages/razer-laptop-control-git/)
 
+### Fedora Workstation (tested on 34, 35, 36)
+#### Requirements
+* dkms: `sudo dnf install dkms`
+* appropriate kernel headers (& possibly kernel-devel): `sudo dnf install kernel-headers kernel-devel`
+* cargo: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+
+#### Driver Installation
+1. Make and install dkms driver.
+```
+cd driver
+sudo make driver_dkms
+sudo dkms add -m razercontrol -v 1.3.0
+sudo dkms build -m razercontrol -v 1.3.0
+sudo dkms install -m razercontrol -v 1.3.0
+```
+2. Rebuild initramfs.
+```
+sudo dracut -v -f
+```
+3. Reboot your computer.
+
+#### Front-end Installation
+1. Compile and install `razer_control_gui`.
+```
+cd razer_control_gui
+./install.sh
+```
+2. Check whether razer laptop control daemon is enabled and running.
+```
+systemctl status razerdaemon.service
+```
+3. To enable it (run automatically)
+```
+systemctl enable razerdaemon.service
+```
+4. If the daemon is running without `exit-code`, enjoy using it!
+5. If the daemon fail to run, you might have secure-boot turned on. Refer [here](#ATTENTION).
+#### 
+
 ### Other distros
 Unfortunatly, you have to build from scrath.
 
@@ -39,6 +78,52 @@ Kernel module required for the software to work
 
 ### razer_control_gui
 Experimental code for system daemon and UI/CLI interface for controlling both RGB aspects and fan+Power subsystem of razer notebooks
+
+## ATTENTION
+If the daemon fail to run, and the log message says "Timed out waiting for sysfs after a minute!", you most likely have secure-boot turned on.
+To get it running on secure-boot enabled devices, you must sign the kernel module yourself. Proceed with caution. **We are NOT reliable for any
+damages done to your computer**.
+
+### Requirements
+* openssl: `sudo dnf install openssl`
+* mokutil: `sudo dnf install mokutil`
+
+### Signing kernel module
+1. Generate a signing key. Replace `~/` to any path that you will remember.
+```
+sudo openssl req -new -x509 -newkey rsa:2048 -keyout ~/private.key -outform DER -out ~/public.der -nodes -days 36500 -subj "/CN=Razer Laptop Control"
+```
+2. Import the key. Replace `~/` with the location of where you saved your key. Note that you can set any password you want (just remember it).
+```
+sudo mokutil --import ~/public.der
+```
+3. Determine where the driver is located at (most likely in `/lib/modules/$(uname -r)/extra/`).
+```
+cd /lib/modules/$(uname -r)/extra/
+ls
+```
+4. You should see `razercontrol.ko` or `razercontrol.ko.xz`. If the driver ends with `.ko`, proceed to step `6`.
+5. Decompress the kernel module.
+```
+sudo unxz razercontrol.ko.xz
+```
+6. Sign the module. Don't forget to replace `~/` to the correct path if you chose to save the keys somewhere else.
+```
+sudo /usr/src/kernels/$(uname -r)/scripts/sign-file sha256 ~/private.key ~/public.der razercontrol.ko
+```
+7. Skip to step `8` if you skipped step `6`. If you had to decompress the module, you must recompress it again.
+```
+sudo xz -f razercontrol.ko
+```
+8. Reboot.
+9. At reboot, `mokutil` will appear (blue screen). Choose `Enroll MOK` -> `Continue` -> type in the password that you have set in step `2`.
+10. VOILA! You have signed your module. The daemon should be running without failing. Try:
+```
+razer-cli read fan
+```
+
+### Side Note
+The key will expire after 36500 days. If you've managed to live that long, you will have to generate a new key, and sign the module using the new key.
 
 ## Changelog
 


### PR DESCRIPTION
Hello! I have seen a few issues regarding sysfs timeout. I have encountered the same issue, though, the issue was due to having secure-boot enabled. In this pull request, I have added steps to guide people on how to make the driver work on secure-boot enabled devices. Although this won't solve every single issue regarding sysfs, it could help a lot of users, especially those who just started learning Linux. I have also added Fedora Workstation documentation because why not 😄 